### PR TITLE
Remove Active Architecture Only when building static lib.

### DIFF
--- a/Blindside.xcodeproj/project.pbxproj
+++ b/Blindside.xcodeproj/project.pbxproj
@@ -798,7 +798,6 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Blindside-StaticLib/Blindside-StaticLib-Prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
This allows the library to be built for iOS devices.
