### PR TITLE
Removed ONLY_ACTIVE_ARCH from Blindside-StaticLib build settings

### DIFF
--- a/Blindside.xcodeproj/project.pbxproj
+++ b/Blindside.xcodeproj/project.pbxproj
@@ -780,6 +780,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Blindside-StaticLib/Blindside-StaticLib-Prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
…  so that the Blindside.framework build artifact will support armv7s (iPhone 5) out of the box.
