### PR TITLE
Injector throws exception when getInstance: returns implicit nil.

### DIFF
--- a/Headers/BSNull.h
+++ b/Headers/BSNull.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
+#define BS_DYNAMIC @"bs_dynamic"
+
 #define BS_NULL [BSNull null]
 
 @interface BSNull : NSObject<NSCopying>

--- a/Headers/Blindside.h
+++ b/Headers/Blindside.h
@@ -17,8 +17,6 @@
 #import "BSBinder.h"
 #import "BSNull.h"
 
-#define BS_DYNAMIC @"bs_dynamic"
-
 @interface Blindside : NSObject 
 
 /**

--- a/Source/BSInjectorImpl.m
+++ b/Source/BSInjectorImpl.m
@@ -106,6 +106,10 @@
         provider = [scope scope:provider];
     }
 
+    if (provider == nil && ![BS_DYNAMIC isEqual:key]) {
+        [NSException raise:@"BSNoProvider" format:@"Injector could not getInstance for key (%@) with args %@", key, args];
+    }
+
     id instance = [provider provide:args injector:self];
     [self injectInjector:instance];
 

--- a/Specs/BSInjectorSpec.mm
+++ b/Specs/BSInjectorSpec.mm
@@ -42,8 +42,15 @@ describe(@"BSInjector", ^{
         instance.bar should equal(@"BAR");
     });
 
+    it(@"raises an exception if the given key produces a nil object", ^{
+        [[^{
+            [injector getInstance:@"NotAnInstance"];
+        } copy] autorelease] should raise_exception();
+    });
+
     describe(@"building an object using a BSInitializer", ^{
         it(@"resolves first-order dependencies", ^{
+            [injector bind:@"theDriveway" toInstance:BS_NULL];
             Address *address = [[[Address alloc] init] autorelease];
             [injector bind:[Address class] toInstance:address];
             House *house = [injector getInstance:[House class]];
@@ -143,6 +150,7 @@ describe(@"BSInjector", ^{
 
             context(@"when the superclass has properties", ^{
                 it(@"injects superclass properties too", ^{
+                    [injector bind:@"10 car driveway" toInstance:BS_NULL];
                     TennisCourt *tennisCourt = [[[TennisCourt alloc] init] autorelease];
                     [injector bind:[TennisCourt class] toInstance:tennisCourt];
 
@@ -170,6 +178,7 @@ describe(@"BSInjector", ^{
     it(@"binds to blocks", ^{
         __block Garage *garage;
 
+        [injector bind:@"theDriveway" toInstance:BS_NULL];
         [injector bind:[Address class] toInstance:BS_NULL];
         
         garage = [[[Garage alloc] init] autorelease];
@@ -184,6 +193,7 @@ describe(@"BSInjector", ^{
     describe(@"binding to classes", ^{
         context(@"when the class has a blindside initializer", ^{
             it(@"builds the class with the blindside initializer", ^{
+                [injector bind:@"theDriveway" toInstance:BS_NULL];
                 [injector bind:[Address class] toInstance:BS_NULL];
                 [injector bind:@"expensivePurchase" toClass:[House class]];
                 id expensivePurchase = [injector getInstance:@"expensivePurchase"];
@@ -203,6 +213,7 @@ describe(@"BSInjector", ^{
     describe(@"scoping", ^{
         describe(@"singleton", ^{
             it(@"uses the same instance for all injection points", ^{
+                [injector bind:@"theDriveway" toInstance:BS_NULL];
                 [injector bind:[Address class] toInstance:BS_NULL];
                 [injector bind:[House class] withScope:[BSSingleton scope]];
                 House *house1 = [injector getInstance:[House class]];
@@ -212,6 +223,7 @@ describe(@"BSInjector", ^{
 
             context(@"when a class is bound to a non-class key", ^{
                 it(@"uses the same instance for all injection points", ^{
+                    [injector bind:@"theDriveway" toInstance:BS_NULL];
                     [injector bind:[Address class] toInstance:BS_NULL];
                     [injector bind:@"house" toClass:[House class]];
                     [injector bind:[House class] withScope:[BSSingleton scope]];
@@ -226,6 +238,7 @@ describe(@"BSInjector", ^{
 
         describe(@"unscoped", ^{
             it(@"uses a different instance for each injection point", ^{
+                [injector bind:@"theDriveway" toInstance:BS_NULL];
                 [injector bind:[Address class] toInstance:BS_NULL];
                 House *house1 = [injector getInstance:[House class]];
                 House *house2 = [injector getInstance:[House class]];
@@ -236,6 +249,7 @@ describe(@"BSInjector", ^{
 
     context(@"when the object being retrieved has a writable blindsideInjector property", ^{
         it(@"injects itself as the property value", ^{
+            [injector bind:@"theDriveway" toInstance:BS_NULL];
             [injector bind:[Address class] toInstance:BS_NULL];
             House *house = [injector getInstance:[House class]];
             house.injector should equal(injector);
@@ -246,14 +260,17 @@ describe(@"BSInjector", ^{
         __block State *state;
         __block City *city;
         __block NSString *street;
+        __block NSString *street2;
         __block NSString *zip;
         
         beforeEach(^{
             street = @"Guerrero";
+            street2 = @"Market";
             zip = @"Guerrero";
             state = [[[State alloc] init] autorelease];
             city = [[[City alloc] init] autorelease];
             [injector bind:@"street" toInstance:street];
+            [injector bind:@"street2" toInstance:street2];
             [injector bind:@"state"  toInstance:state];
         });
         
@@ -261,7 +278,7 @@ describe(@"BSInjector", ^{
             it(@"raises an exception", ^{
                 
                 void(^block)() = [[^{
-                   [injector getInstance:[Address class] withArgs:city, zip, @"too many args", nil];
+                   [injector getInstance:[Intersection class] withArgs:city, zip, @"too many args", nil];
                 } copy] autorelease];
                 
                 block should raise_exception();
@@ -270,9 +287,8 @@ describe(@"BSInjector", ^{
 
         context(@"when there are too few args", ^{
             it(@"raises an exception", ^{
-                
                 void(^block)() = [[^{
-                    [injector getInstance:[Address class] withArgs:city, nil];
+                    [injector getInstance:[Intersection class] withArgs:city, nil];
                 } copy] autorelease];
                 
                 block should raise_exception();                
@@ -281,21 +297,23 @@ describe(@"BSInjector", ^{
 
         context(@"with the correct number of args", ^{
             it(@"injects the provided args along with existing bindings", ^{
-                Address *address = [injector getInstance:[Address class] withArgs:city, zip, nil];
-                address.street should equal(street);
-                address.state should equal(state);
-                address.city should equal(city);
-                address.zip should equal(zip);
+                Intersection *intersection = [injector getInstance:[Intersection class] withArgs:city, zip, nil];
+                intersection.street should equal(street);
+                intersection.street2 should equal(street2);
+                intersection.state should equal(state);
+                intersection.city should equal(city);
+                intersection.zip should equal(zip);
             });
         });
         
         context(@"when passing BS_NULL as an arg value", ^{
             it(@"injects nil", ^{
-                Address *address = [injector getInstance:[Address class] withArgs:BS_NULL, zip, nil];
-                address.street should equal(street);
-                address.state should equal(state);
-                address.city should be_nil;
-                address.zip should equal(zip);                
+                Intersection *intersection = [injector getInstance:[Intersection class] withArgs:BS_NULL, zip, nil];
+                intersection.street should equal(street);
+                intersection.street2 should equal(street2);
+                intersection.state should equal(state);
+                intersection.city should be_nil;
+                intersection.zip should equal(zip);
             });
         });
     });

--- a/Specs/Fixtures.h
+++ b/Specs/Fixtures.h
@@ -30,6 +30,14 @@
 
 @end
 
+@interface Intersection : NSObject
+@property (nonatomic, retain) NSString *street;
+@property (nonatomic, retain) NSString *street2;
+@property (nonatomic, retain) City *city;
+@property (nonatomic, retain) State *state;
+@property (nonatomic, retain) NSString *zip;
+@end
+
 @interface House : NSObject
 
 @property (nonatomic, retain) Address *address;

--- a/Specs/Fixtures.m
+++ b/Specs/Fixtures.m
@@ -6,6 +6,7 @@
 
 #import <objc/runtime.h>
 
+
 @implementation State
 @end
 
@@ -53,6 +54,38 @@ zip = zip_;
 - (id)initWithStreet:(NSString *)street city:(City *)city state:(State *)state zip:(NSString *)zip {
     if (self = [super init]) {
         self.street = street;
+        self.city = city;
+        self.state = state;
+        self.zip = zip;
+    }
+    return self;
+}
+
+@end
+
+@implementation Intersection
+
+@synthesize
+street = street_,
+street2 = street2_,
+city = city_,
+state = state_,
+zip = zip_;
+
++ (BSInitializer *)bsInitializer {
+    return [BSInitializer initializerWithClass:self
+                                      selector:@selector(initWithStreet:andStreet:city:state:zip:)
+                                  argumentKeys:@"street", @"street2", BS_DYNAMIC, @"state", BS_DYNAMIC, nil];
+}
+
+- (id)initWithStreet:(NSString *)street
+           andStreet:(NSString *)street2
+                city:(City *)city
+               state:(State *)state
+                 zip:(NSString *)zip {
+    if (self = [super init]) {
+        self.street = street;
+        self.street2 = street2;
         self.city = city;
         self.state = state;
         self.zip = zip;


### PR DESCRIPTION
Unless it's BS_DYNAMIC.

So something like this:

[injector getInstance:@"foo"];

will raise an exception if @"foo" is binded.
