### PR TITLE
Injector is now set automatically on properties named 'injector' that co...

### DIFF
--- a/Source/BSInjectorImpl.m
+++ b/Source/BSInjectorImpl.m
@@ -70,7 +70,7 @@
 
     const char *attributes = property_getAttributes(objc_property);
     NSString *attrStr = [NSString stringWithUTF8String:attributes];
-    NSRange startRange = [attrStr rangeOfString:@"T@\"<BSInjector>\""];
+    NSRange startRange = [attrStr rangeOfString:@"<BSInjector>"];
 
     if (startRange.location != NSNotFound) {
         [object setValue:self forKey:@"injector"];

--- a/Specs/BSInjectorSpec.mm
+++ b/Specs/BSInjectorSpec.mm
@@ -256,6 +256,13 @@ describe(@"BSInjector", ^{
         });
     });
 
+    context(@"when the object being retrieved has a writable injector property that also conforms to a protocol other than BSInjector", ^{
+        it(@"injects itself as the property value", ^{
+            Cottage *cottage = [injector getInstance:[Cottage class]];
+            cottage.injector should equal(injector);
+        });
+    });
+
     describe(@"getInstance:withArgs:", ^{
         __block State *state;
         __block City *city;

--- a/Specs/Fixtures.h
+++ b/Specs/Fixtures.h
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 
 @protocol BSInjector;
+@protocol BSBinder;
 @class BSInitializer;
 
 @interface State : NSObject
@@ -46,6 +47,10 @@
 @property (nonatomic, assign) id<BSInjector> injector;
 
 - (id)initWithAddress:(Address *)address;
+@end
+
+@interface Cottage : NSObject
+@property (nonatomic, assign) id<BSInjector, BSBinder> injector;
 @end
 
 @interface TennisCourt : NSObject

--- a/Specs/Fixtures.m
+++ b/Specs/Fixtures.m
@@ -118,6 +118,9 @@ zip = zip_;
 
 @end
 
+@implementation Cottage
+@end
+
 @implementation TennisCourt
 @end
 


### PR DESCRIPTION
...nform to the <BSInjector> protocol, even if they also conform to some other protocols as well.  Previously if 'injector' conformed to any protocols other than just <BSInjector>, the 'injector' property would not be set with the injector.
