### PR TITLE
Declare that Blindside can be used in app extensions

### DIFF
--- a/Blindside.xcodeproj/project.pbxproj
+++ b/Blindside.xcodeproj/project.pbxproj
@@ -1325,6 +1325,7 @@
 		AE4864D11B066F11005DB302 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -1362,6 +1363,7 @@
 		AE4864D21B066F11005DB302 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
Without this flag, having an app extension depend on Blindside causes warnings. The only possible downside is you cannot depend on a few pieces of UIKit that are not allowed to be used in app extensions. The only example I know of is `UIApplication`. All the specs still passed after we made this change.