### PR TITLE
Add nullability annotations.

### DIFF
--- a/Blindside.xcodeproj/project.pbxproj
+++ b/Blindside.xcodeproj/project.pbxproj
@@ -117,6 +117,9 @@
 		29D7FE90153EAEF000C8C4E7 /* BSPropertySet.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D7FE86153EAEF000C8C4E7 /* BSPropertySet.m */; };
 		29D7FE91153EAEF000C8C4E7 /* BSPropertySet.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D7FE86153EAEF000C8C4E7 /* BSPropertySet.m */; };
 		29D7FE92153EAEF000C8C4E7 /* BSPropertySet.m in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = 29D7FE86153EAEF000C8C4E7 /* BSPropertySet.m */; };
+		3453B89C1B4F7B0E00026E19 /* BSNullabilityCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 3453B88F1B4F7AF700026E19 /* BSNullabilityCompat.h */; };
+		3453B89D1B4F7B1600026E19 /* BSNullabilityCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 3453B88F1B4F7AF700026E19 /* BSNullabilityCompat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3453B89E1B4F7B1A00026E19 /* BSNullabilityCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 3453B88F1B4F7AF700026E19 /* BSNullabilityCompat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6172C028155B98FF00348C4E /* BSClassProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 6172C027155B98E900348C4E /* BSClassProvider.h */; };
 		6172C029155B990000348C4E /* BSClassProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 6172C027155B98E900348C4E /* BSClassProvider.h */; };
 		6172C02A155B990100348C4E /* BSClassProvider.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = 6172C027155B98E900348C4E /* BSClassProvider.h */; };
@@ -343,6 +346,7 @@
 		29D7FE84153EAEF000C8C4E7 /* BSBlockProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSBlockProvider.m; path = Source/BSBlockProvider.m; sourceTree = "<group>"; };
 		29D7FE85153EAEF000C8C4E7 /* BSProperty.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSProperty.m; path = Source/BSProperty.m; sourceTree = "<group>"; };
 		29D7FE86153EAEF000C8C4E7 /* BSPropertySet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSPropertySet.m; path = Source/BSPropertySet.m; sourceTree = "<group>"; };
+		3453B88F1B4F7AF700026E19 /* BSNullabilityCompat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSNullabilityCompat.h; sourceTree = "<group>"; };
 		6172C027155B98E900348C4E /* BSClassProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSClassProvider.h; sourceTree = "<group>"; };
 		61DC9F771541FA82009DDFA6 /* BSInjectorImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSInjectorImpl.h; sourceTree = "<group>"; };
 		AE03FC1A1B0A57DD00013784 /* Blindside-iOS-Framework BuildTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Blindside-iOS-Framework BuildTest.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -438,6 +442,7 @@
 				29C967661508919300356446 /* BSScope.h */,
 				29C967D01509BF1100356446 /* BSSingleton.h */,
 				29C967581508744900356446 /* NSObject+Blindside.h */,
+				3453B88F1B4F7AF700026E19 /* BSNullabilityCompat.h */,
 			);
 			path = Headers;
 			sourceTree = "<group>";
@@ -618,6 +623,7 @@
 				29B5068A15276D630035D197 /* BSBinder.h in Headers */,
 				61DC9F791541FA8E009DDFA6 /* BSInjectorImpl.h in Headers */,
 				6172C029155B990000348C4E /* BSClassProvider.h in Headers */,
+				3453B89C1B4F7B0E00026E19 /* BSNullabilityCompat.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -642,6 +648,7 @@
 				29B50684152583840035D197 /* BSBinder.h in Headers */,
 				61DC9F781541FA8D009DDFA6 /* BSInjectorImpl.h in Headers */,
 				6172C028155B98FF00348C4E /* BSClassProvider.h in Headers */,
+				3453B89D1B4F7B1600026E19 /* BSNullabilityCompat.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -666,6 +673,7 @@
 				AE4864D81B066F35005DB302 /* BSBlockProvider.h in Headers */,
 				AE4864DD1B066F35005DB302 /* BSInjectorImpl.h in Headers */,
 				AE4864D91B066F35005DB302 /* BSClassProvider.h in Headers */,
+				3453B89E1B4F7B1A00026E19 /* BSNullabilityCompat.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Headers/BSBinder.h
+++ b/Headers/BSBinder.h
@@ -1,8 +1,11 @@
 #import <Foundation/Foundation.h>
 
 #import "BSBlockProvider.h"
+#import "BSNullabilityCompat.h"
 
 @protocol BSProvider, BSScope;
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * The BSBinder interface is used in configuration of Blindside. Using BSBinder,
@@ -124,3 +127,5 @@
 - (void)bind:(id)key withScope:(id<BSScope>)scope;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/BSBlockProvider.h
+++ b/Headers/BSBlockProvider.h
@@ -1,8 +1,11 @@
 #import <Foundation/Foundation.h>
 
 #import "BSProvider.h"
+#import "BSNullabilityCompat.h"
 
 @protocol BSInjector;
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Typedef for blocks used by Blindside. Such blocks take an NSArray * of args and return
@@ -15,7 +18,7 @@
  * @param injector The BSInjector invoking the block. Can be used by blocks that need
  *        it and ignored by blocks that don't.
  */
-typedef id(^BSBlock)(NSArray *args, id<BSInjector> injector);
+typedef __nonnull id(^BSBlock)(NSArray *args, id<BSInjector> injector);
 
 /**
  * Used internally by Blindside when a key is bound to a block. BSBlockProvider 
@@ -29,3 +32,5 @@ typedef id(^BSBlock)(NSArray *args, id<BSInjector> injector);
 + (BSBlockProvider *)providerWithBlock:(BSBlock)block;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/BSClassProvider.h
+++ b/Headers/BSClassProvider.h
@@ -1,11 +1,16 @@
 #import <Foundation/Foundation.h>
 
 #import "BSProvider.h"
+#import "BSNullabilityCompat.h"
 
 @protocol BSInjector;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface BSClassProvider : NSObject<BSProvider> 
 
 + (BSClassProvider *)providerWithClass:(Class)class;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/BSInitializer.h
+++ b/Headers/BSInitializer.h
@@ -1,12 +1,16 @@
 #import <Foundation/Foundation.h>
 
+#import "BSNullabilityCompat.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * A BSInitializer describes an initializer method that Blindside will use when constructing
  * objects of a given class. 
  */
 @interface BSInitializer : NSObject 
 
-@property (nonatomic, weak, readonly) Class type;
+@property (nonatomic, strong, readonly) Class type;
 @property (nonatomic, readonly) SEL selector;
 @property (nonatomic, strong, readonly) NSArray *argumentKeys;
 
@@ -69,7 +73,7 @@
  * \endcode
  * 
  */
-+ (BSInitializer *)initializerWithClass:(Class)type selector:(SEL)selector argumentKeys:(id)firstKey, ... NS_REQUIRES_NIL_TERMINATION;
++ (BSInitializer *)initializerWithClass:(Class)type selector:(SEL)selector argumentKeys:(nullable id)firstKey, ... NS_REQUIRES_NIL_TERMINATION;
 
 /**
  * Creates a BSInitializer representing the given class and selector. This is an important method
@@ -88,7 +92,7 @@
  * keys are commonly classes, representing the class of the needed dependency, or strings, representing an
  * actual object instance configured elsewhere in Blindside.
  */
-+ (BSInitializer *)initializerWithClass:(Class)type classSelector:(SEL)selector argumentKeys:(id)firstKey, ...
++ (BSInitializer *)initializerWithClass:(Class)type classSelector:(SEL)selector argumentKeys:(nullable id)firstKey, ...
     NS_REQUIRES_NIL_TERMINATION;
 
 /**
@@ -101,3 +105,5 @@
 - (id)bsPerform:(NSArray *)argumentValues;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/BSInitializerProvider.h
+++ b/Headers/BSInitializerProvider.h
@@ -1,7 +1,11 @@
 #import <Foundation/Foundation.h>
 
 #import "BSProvider.h"
+#import "BSNullabilityCompat.h"
+
 @class BSInitializer;
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Implementation of BSProvider that wraps a BSInitializer. Instances of BSInitializerProvider are 
@@ -14,3 +18,5 @@
 + (BSInitializerProvider *)providerWithInitializer:(BSInitializer *)initializer;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/BSInjector.h
+++ b/Headers/BSInjector.h
@@ -1,7 +1,13 @@
 #import <Foundation/Foundation.h>
 
+#import "BSNullabilityCompat.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol BSInjector
 - (id)getInstance:(id)key;
-- (id)getInstance:(id)key withArgs:(id)arg1, ... NS_REQUIRES_NIL_TERMINATION;
+- (id)getInstance:(id)key withArgs:(nullable id)arg1, ... NS_REQUIRES_NIL_TERMINATION;
 - (void)injectProperties:(id)instance;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/BSInjectorImpl.h
+++ b/Headers/BSInjectorImpl.h
@@ -2,6 +2,11 @@
 
 #import "BSBinder.h"
 #import "BSInjector.h"
+#import "BSNullabilityCompat.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface BSInjectorImpl : NSObject<BSBinder, BSInjector>
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/BSInstanceProvider.h
+++ b/Headers/BSInstanceProvider.h
@@ -1,9 +1,14 @@
 #import <Foundation/Foundation.h>
 
 #import "BSProvider.h"
+#import "BSNullabilityCompat.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface BSInstanceProvider : NSObject<BSProvider> 
 
 + (BSInstanceProvider *)provider:(id)instance;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/BSModule.h
+++ b/Headers/BSModule.h
@@ -1,7 +1,13 @@
 #import <Foundation/Foundation.h>
 
+#import "BSNullabilityCompat.h"
+
 @protocol BSBinder;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @protocol BSModule
 - (void)configure:(id<BSBinder>)binder;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/BSNull.h
+++ b/Headers/BSNull.h
@@ -1,11 +1,17 @@
 #import <Foundation/Foundation.h>
 
+#import "BSNullabilityCompat.h"
+
 #define BS_DYNAMIC @"bs_dynamic"
 
 #define BS_NULL [BSNull null]
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface BSNull : NSObject<NSCopying>
 
 + (BSNull *)null;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/BSNullabilityCompat.h
+++ b/Headers/BSNullabilityCompat.h
@@ -1,0 +1,16 @@
+
+#if !__has_feature(nullability)
+#ifndef NS_ASSUME_NONNULL_BEGIN
+
+#define NS_ASSUME_NONNULL_BEGIN
+#define NS_ASSUME_NONNULL_END
+#define nullable
+#define nonnull
+#define null_unspecified
+#define null_resettable
+#define __nullable
+#define __nonnull
+#define __null_unspecified
+
+#endif
+#endif

--- a/Headers/BSProperty.h
+++ b/Headers/BSProperty.h
@@ -1,15 +1,21 @@
 #import <Foundation/Foundation.h>
 
+#import "BSNullabilityCompat.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * A representation of an Objective-C property
  */
 @interface BSProperty : NSObject
 
-@property (nonatomic, strong) id injectionKey;
-@property (nonatomic, weak, readonly) Class returnType;
+@property (nonatomic, strong, null_resettable) id injectionKey;
+@property (nonatomic, strong, readonly) Class returnType;
 @property (nonatomic, strong, readonly) NSString *propertyNameString;
 
 + (BSProperty *)propertyWithClass:(Class)owningClass propertyNameString:(NSString *)propertyNameString;
 
 - (id)injectionKey;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/BSPropertySet.h
+++ b/Headers/BSPropertySet.h
@@ -1,6 +1,9 @@
 #import <Foundation/Foundation.h>
 
 #import <Foundation/NSEnumerator.h>
+#import "BSNullabilityCompat.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A BSPropertySet represents the set of a Class' properties that will be injected into class instances after
@@ -34,3 +37,5 @@
 - (void)bindProperty:(NSString *)propertyName toKey:(id)key;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/BSProvider.h
+++ b/Headers/BSProvider.h
@@ -1,7 +1,15 @@
 #import <Foundation/Foundation.h>
+
+#import "BSNullabilityCompat.h"
+
 @protocol BSInjector;
+
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol BSProvider <NSObject>
 
 - (id)provide:(NSArray *)args injector:(id<BSInjector>)injector;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/BSScope.h
+++ b/Headers/BSScope.h
@@ -1,6 +1,9 @@
 #import <Foundation/Foundation.h>
 
 #import "BSProvider.h"
+#import "BSNullabilityCompat.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Implementations of BSScope determine when new object instances will be created or retrieved,
@@ -20,3 +23,4 @@
 - (id<BSProvider>)scope:(id<BSProvider>)source;
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Headers/BSSingleton.h
+++ b/Headers/BSSingleton.h
@@ -2,8 +2,11 @@
 
 #import "BSScope.h"
 #import "BSProvider.h"
+#import "BSNullabilityCompat.h"
 
 @class BSInstanceProvider;
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * The BSSingelton scope is used to define bindings for which the same object instance
@@ -32,3 +35,5 @@
 + (BSSingleton *)scope;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/Blindside.h
+++ b/Headers/Blindside.h
@@ -17,6 +17,9 @@
 #import "BSBinder.h"
 #import "BSNull.h"
 #import "BSBlockProvider.h"
+#import "BSNullabilityCompat.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface Blindside : NSObject
 
@@ -33,3 +36,5 @@
 + (id<BSInjector>)injectorWithModules:(NSArray *)modules;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/NSObject+Blindside.h
+++ b/Headers/NSObject+Blindside.h
@@ -1,14 +1,20 @@
 #import <Foundation/Foundation.h>
 
+#import "BSNullabilityCompat.h"
+
 @class BSInitializer, BSPropertySet;
 @protocol BSInjector;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface NSObject(Blindside)
 
 + (id)bsCreateWithArgs:(NSArray *)args injector:(id<BSInjector>)injector;
 
-+ (BSInitializer *)bsInitializer;
++ (nullable BSInitializer *)bsInitializer;
 
-+ (BSPropertySet *)bsProperties;
++ (nullable BSPropertySet *)bsProperties;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/BSClassProvider.m
+++ b/Source/BSClassProvider.m
@@ -2,7 +2,7 @@
 #import "BSInjector.h"
 
 @interface BSClassProvider ()
-@property (nonatomic, weak) Class klass;
+@property (nonatomic, strong) Class klass;
 
 - (id)initWithClass:(Class)class;
 

--- a/Source/BSInitializer.m
+++ b/Source/BSInitializer.m
@@ -6,7 +6,7 @@
 static NSString *const BSInvalidInitializerException = @"BSInvalidInitializerException";
 
 @interface BSInitializer ()
-@property (nonatomic, weak, readwrite) Class type;
+@property (nonatomic, strong, readwrite) Class type;
 @property (nonatomic) SEL selector;
 @property (nonatomic) BOOL canAlloc;
 @property (nonatomic, strong) NSMethodSignature *signature;

--- a/Source/BSProperty.m
+++ b/Source/BSProperty.m
@@ -4,8 +4,8 @@
 static NSString *const BSInvalidPropertyException = @"BSInvalidPropertyException";
 
 @interface BSProperty ()
-@property (nonatomic, weak) Class owningClass;
-@property (nonatomic, weak, readwrite) Class returnType;
+@property (nonatomic, strong) Class owningClass;
+@property (nonatomic, strong, readwrite) Class returnType;
 @property (nonatomic, strong, readwrite) NSString *propertyNameString;
 
 - (id)initWithClass:(Class)owningClass propertyName:(NSString *)propertyName;

--- a/Source/BSPropertySet.m
+++ b/Source/BSPropertySet.m
@@ -5,7 +5,7 @@
 #import <objc/runtime.h>
 
 @interface BSPropertySet ()
-@property (nonatomic, weak) Class owningClass;
+@property (nonatomic, strong) Class owningClass;
 @property (nonatomic, strong) NSMutableArray *properties;
 
 - (id)initWithClass:(Class)owningClass properties:(NSMutableArray *)properties;


### PR DESCRIPTION
Enables better Swift interface generation and better warnings if the
API is being used incorrectly. A compat header is included to not break
Xcode <6.3