### PR TITLE
Show a helpful diagnostic message if default object construction fails

### DIFF
--- a/Source/NSObject+Blindside.m
+++ b/Source/NSObject+Blindside.m
@@ -3,10 +3,28 @@
 #import "BSInjector.h"
 #import "BSPropertySet.h"
 
+static NSString *const BSMissingInitializerSpecificationException = @"BSMissingInitializerSpecificationException";
+
 @implementation NSObject(Blindside)
 
 + (id)bsCreateWithArgs:(NSArray *)args injector:(id<BSInjector>)injector {
-    id instance = [[self alloc] init];
+    id instance;
+
+    @try {
+        instance = [[self alloc] init];
+    } @catch (NSException *exception) {
+        BOOL isUnrecognizedSelectorException = ([exception.name isEqualToString:NSInvalidArgumentException] &&
+                                                [exception.reason rangeOfString:@"unrecognized selector"].location != NSNotFound);
+        if (!isUnrecognizedSelectorException) {
+            @throw;
+        }
+    }
+
+    if (!instance) {
+        [NSException raise:BSMissingInitializerSpecificationException
+                    format:@"Unable to create an instance of class %@ using -init. Override +bsInitializer to tell Blindside which initializer to use.", NSStringFromClass(self)];
+    }
+
     [injector injectProperties:instance];
     return instance;
 }

--- a/Specs/BSInjectorSpec.mm
+++ b/Specs/BSInjectorSpec.mm
@@ -216,6 +216,14 @@ describe(@"BSInjector", ^{
                 expect(address).to(be_instance_of([TennisCourt class]));
             });
         });
+
+        context(@"when the class has a designated initializer but does not declare a blindside initializer", ^{
+            it(@"raises an exception", ^{
+                ^{
+                    [injector getInstance:[ClassWithoutDependencyDeclaration class]];
+                } should raise_exception().with_name(@"BSMissingInitializerSpecificationException");
+            });
+        });
     });
 
     describe(@"scoping", ^{

--- a/Specs/Fixtures.h
+++ b/Specs/Fixtures.h
@@ -76,10 +76,14 @@
 + bsCreateWithArgs:(NSArray *)args injector:(id<BSInjector>)injector;
 @end
 
-
 @class BogusClass;
 @interface ClassWithBogusProperty : NSObject
 @property (nonatomic, strong) BogusClass *bogus;
+@end
+
+@interface ClassWithoutDependencyDeclaration : NSObject
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithDependency:(NSString *)dependency NS_DESIGNATED_INITIALIZER;
 @end
 
 

--- a/Specs/Fixtures.m
+++ b/Specs/Fixtures.m
@@ -126,6 +126,11 @@ zip = zip_;
 @end
 
 @implementation TennisCourt
+
+- (instancetype)init {
+    return [super init];
+}
+
 @end
 
 @implementation Mansion
@@ -164,6 +169,19 @@ zip = zip_;
 @end
 
 @implementation ClassWithBogusProperty
+@end
+
+@implementation ClassWithoutDependencyDeclaration
+
+- (instancetype)init {
+    [self doesNotRecognizeSelector:_cmd];
+    return nil;
+}
+
+- (instancetype)initWithDependency:(NSString *)dependency {
+    return [super init];
+}
+
 @end
 
 @implementation ClassADependsOnB


### PR DESCRIPTION
Here's another attempt at resolving #24 that isn't as strict as #40 was.