### PR TITLE
Don’t inject BSNull when performing property injection

### DIFF
--- a/Source/BSInjectorImpl.m
+++ b/Source/BSInjectorImpl.m
@@ -122,6 +122,8 @@ static NSString *const BSInFlightKeysDictKey = @"BSInFlightKeysDictKey";
         BSPropertySet *propertySet = [[instance class] performSelector:@selector(bsProperties)];
         for (BSProperty *property in propertySet) {
             id value = [self getInstance:property.injectionKey];
+            value = (value==[BSNull null]) ? nil : value;
+
             [instance setValue:value forKey:property.propertyNameString];
         }
     }

--- a/Specs/BSInjectorSpec.mm
+++ b/Specs/BSInjectorSpec.mm
@@ -140,6 +140,15 @@ describe(@"BSInjector", ^{
                     expect(house.garage == garage).to(equal(YES));
                 });
             });
+
+            context(@"when the property is bound to BS_NULL", ^{
+                it(@"injects nil", ^{
+                    [injector bind:@"theDriveway" toInstance:BS_NULL];
+
+                    House *house = [injector getInstance:[House class]];
+                    expect(house.driveway).to(be_nil());
+                });
+            });
             
             context(@"when the class implements bsAwakeFromPropertyInjection", ^{
                 it(@"should call it after property injection", ^{


### PR DESCRIPTION
- This makes it match the behavior of BSInitializer