### PR TITLE
Remove conditional from the tvOS declaration in the podspec

### DIFF
--- a/Blindside.podspec
+++ b/Blindside.podspec
@@ -11,10 +11,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
   s.watchos.deployment_target = '2.0'
-
-  if s.respond_to?(:tvos)
-    s.tvos.deployment_target = '9.0'
-  end
+  s.tvos.deployment_target = '9.0'
 
   s.source_files = "{Source,Headers}/**/*.{h,m}"
   s.public_header_files = "Headers/Public/*.h"


### PR DESCRIPTION
It seems that when Cocoapods Trunk generated the JSON representation of the podspec for the last release, the tvOS platform support didn't get included. Now that tvOS support is included in the public Cocoapods release, we can remove the conditional and cut a patch release.