### PR TITLE
Use Cedar submodule over HTTPS instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Externals/Cedar"]
 	path = Externals/Cedar
-	url = git://github.com/pivotal/cedar.git
+	url = https://github.com/pivotal/cedar.git


### PR DESCRIPTION
In general, this is a nicer URL to use because traffic over 443 is often allowed, but outbound traffic on 22 may be blocked. 

We're using Blindside with Carthage, which wants to pull down all of the dependencies, even though building the Blindside framework realistically should not require this test dependency.