### PR TITLE
Include protocol names when printing injector keys in diagnostics.

### DIFF
--- a/Blindside.xcodeproj/project.pbxproj
+++ b/Blindside.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		347C245F1BA0CC61009BE82F /* BSNullabilityCompat.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = 3453B88F1B4F7AF700026E19 /* BSNullabilityCompat.h */; };
 		347C24601BA0CD17009BE82F /* BSBlockProvider.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = 294B3C311522C84E001A69D3 /* BSBlockProvider.h */; };
 		347C24701BA0D16C009BE82F /* BSInjectorSwiftSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 347C246F1BA0D16C009BE82F /* BSInjectorSwiftSpec.mm */; };
+		349AD2B51C4D689500DD33E4 /* NSObject+BlindsidePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = AEBA4F121C4D628800C2FF80 /* NSObject+BlindsidePrivate.h */; };
 		34A18BE01B9F887300A65DB3 /* Blindside-watchOS BuildTest Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 34A18BDF1B9F887300A65DB3 /* Blindside-watchOS BuildTest Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		34A18BEF1B9F887300A65DB3 /* Blindside-watchOS BuildTest.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 34A18BD31B9F887200A65DB3 /* Blindside-watchOS BuildTest.app */; };
 		34A18C0B1B9F890F00A65DB3 /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 34A18C091B9F88F700A65DB3 /* Interface.storyboard */; };
@@ -211,6 +212,15 @@
 		AE4864F01B06735F005DB302 /* BSPropertySet.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D7FE86153EAEF000C8C4E7 /* BSPropertySet.m */; };
 		AE4864F11B06735F005DB302 /* BSSingleton.m in Sources */ = {isa = PBXBuildFile; fileRef = 29C967D81509BF2100356446 /* BSSingleton.m */; };
 		AE4864F21B06735F005DB302 /* NSObject+Blindside.m in Sources */ = {isa = PBXBuildFile; fileRef = 29C967591508744900356446 /* NSObject+Blindside.m */; };
+		AEBA4F151C4D628800C2FF80 /* NSObject+BlindsidePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = AEBA4F121C4D628800C2FF80 /* NSObject+BlindsidePrivate.h */; };
+		AEBA4F161C4D628800C2FF80 /* NSObject+BlindsidePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = AEBA4F121C4D628800C2FF80 /* NSObject+BlindsidePrivate.h */; };
+		AEBA4F171C4D628800C2FF80 /* NSObject+BlindsidePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = AEBA4F121C4D628800C2FF80 /* NSObject+BlindsidePrivate.h */; };
+		AEBA4F181C4D628800C2FF80 /* NSObject+BlindsidePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = AEBA4F121C4D628800C2FF80 /* NSObject+BlindsidePrivate.h */; };
+		AEBA4F191C4D628800C2FF80 /* NSObject+BlindsidePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = AEBA4F131C4D628800C2FF80 /* NSObject+BlindsidePrivate.m */; };
+		AEBA4F1A1C4D628800C2FF80 /* NSObject+BlindsidePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = AEBA4F131C4D628800C2FF80 /* NSObject+BlindsidePrivate.m */; };
+		AEBA4F1B1C4D628800C2FF80 /* NSObject+BlindsidePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = AEBA4F131C4D628800C2FF80 /* NSObject+BlindsidePrivate.m */; };
+		AEBA4F1C1C4D628800C2FF80 /* NSObject+BlindsidePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = AEBA4F131C4D628800C2FF80 /* NSObject+BlindsidePrivate.m */; };
+		AEBA4F1D1C4D628800C2FF80 /* NSObject+BlindsidePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = AEBA4F131C4D628800C2FF80 /* NSObject+BlindsidePrivate.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -453,6 +463,8 @@
 		AE03FC1E1B0A57DD00013784 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		AE03FC211B0A57DD00013784 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		AE4864BD1B066F11005DB302 /* Blindside.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Blindside.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AEBA4F121C4D628800C2FF80 /* NSObject+BlindsidePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+BlindsidePrivate.h"; sourceTree = "<group>"; };
+		AEBA4F131C4D628800C2FF80 /* NSObject+BlindsidePrivate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+BlindsidePrivate.m"; path = "Source/NSObject+BlindsidePrivate.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -542,6 +554,7 @@
 				29D7FE86153EAEF000C8C4E7 /* BSPropertySet.m */,
 				29C967D81509BF2100356446 /* BSSingleton.m */,
 				29C967591508744900356446 /* NSObject+Blindside.m */,
+				AEBA4F131C4D628800C2FF80 /* NSObject+BlindsidePrivate.m */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -677,6 +690,7 @@
 				29997B071505D8FE00C12110 /* BSInstanceProvider.h */,
 				29C967EA150C50ED00356446 /* BSProperty.h */,
 				347C24621BA0CEF8009BE82F /* BSUtils.h */,
+				AEBA4F121C4D628800C2FF80 /* NSObject+BlindsidePrivate.h */,
 			);
 			path = Private;
 			sourceTree = "<group>";
@@ -739,6 +753,7 @@
 				29C967D21509BF1100356446 /* BSNull.h in Headers */,
 				29C967D51509BF1100356446 /* BSSingleton.h in Headers */,
 				29C967E3150C4E1A00356446 /* BSPropertySet.h in Headers */,
+				AEBA4F181C4D628800C2FF80 /* NSObject+BlindsidePrivate.h in Headers */,
 				29C967EC150C50EE00356446 /* BSProperty.h in Headers */,
 				294B3C3C1522C85E001A69D3 /* BSBlockProvider.h in Headers */,
 				29B5068A15276D630035D197 /* BSBinder.h in Headers */,
@@ -765,6 +780,7 @@
 				29C967D11509BF1100356446 /* BSNull.h in Headers */,
 				34E3BCD61B4F8ADD0007037F /* BSBinder.h in Headers */,
 				29C967D41509BF1100356446 /* BSSingleton.h in Headers */,
+				349AD2B51C4D689500DD33E4 /* NSObject+BlindsidePrivate.h in Headers */,
 				29C967E2150C4E1A00356446 /* BSPropertySet.h in Headers */,
 				29C967EB150C50EE00356446 /* BSProperty.h in Headers */,
 				294B3C321522C84E001A69D3 /* BSBlockProvider.h in Headers */,
@@ -791,6 +807,7 @@
 				3420FD001BAA2BE700AF22F0 /* Blindside.h in Headers */,
 				3420FD0B1BAA2BE700AF22F0 /* BSSingleton.h in Headers */,
 				3420FD071BAA2BE700AF22F0 /* BSNullabilityCompat.h in Headers */,
+				AEBA4F171C4D628800C2FF80 /* NSObject+BlindsidePrivate.h in Headers */,
 				3420FD031BAA2BE700AF22F0 /* BSInitializer.h in Headers */,
 				3420FD0F1BAA2BF200AF22F0 /* BSInjectorImpl.h in Headers */,
 				3420FD0C1BAA2BE700AF22F0 /* NSObject+Blindside.h in Headers */,
@@ -817,6 +834,7 @@
 				34E710C61B9F86190088AB71 /* BSInjectorImpl.h in Headers */,
 				34E710C41B9F86190088AB71 /* BSInitializerProvider.h in Headers */,
 				34E710CD1B9F86190088AB71 /* BSScope.h in Headers */,
+				AEBA4F161C4D628800C2FF80 /* NSObject+BlindsidePrivate.h in Headers */,
 				34E710CE1B9F86190088AB71 /* BSSingleton.h in Headers */,
 				34E710C51B9F86190088AB71 /* BSInjector.h in Headers */,
 				34E710C31B9F86190088AB71 /* BSInitializer.h in Headers */,
@@ -843,6 +861,7 @@
 				AE4864E51B066F35005DB302 /* BSSingleton.h in Headers */,
 				AE4864E31B066F35005DB302 /* BSPropertySet.h in Headers */,
 				AE4864E11B066F35005DB302 /* BSProperty.h in Headers */,
+				AEBA4F151C4D628800C2FF80 /* NSObject+BlindsidePrivate.h in Headers */,
 				AE4864D71B066F35005DB302 /* BSBinder.h in Headers */,
 				AE4864E01B066F35005DB302 /* BSNull.h in Headers */,
 				AE4864D81B066F35005DB302 /* BSBlockProvider.h in Headers */,
@@ -1286,6 +1305,7 @@
 			files = (
 				29997B521505EC4500C12110 /* BSInjectorImpl.m in Sources */,
 				29997B531505EC4500C12110 /* BSInstanceProvider.m in Sources */,
+				AEBA4F1D1C4D628800C2FF80 /* NSObject+BlindsidePrivate.m in Sources */,
 				29997B551505EC4500C12110 /* BSInitializer.m in Sources */,
 				29997B561505EC4500C12110 /* BSInitializerProvider.m in Sources */,
 				29C9675F1508744900356446 /* NSObject+Blindside.m in Sources */,
@@ -1305,6 +1325,7 @@
 			files = (
 				29997A7E1502C48B00C12110 /* BSInjectorImpl.m in Sources */,
 				29997A811502C48B00C12110 /* BSInstanceProvider.m in Sources */,
+				AEBA4F191C4D628800C2FF80 /* NSObject+BlindsidePrivate.m in Sources */,
 				29997B111505D94200C12110 /* BSInitializer.m in Sources */,
 				29997B121505D94200C12110 /* BSInitializerProvider.m in Sources */,
 				29C9675D1508744900356446 /* NSObject+Blindside.m in Sources */,
@@ -1338,6 +1359,7 @@
 			files = (
 				3420FCFF1BAA2B9C00AF22F0 /* NSObject+Blindside.m in Sources */,
 				3420FCF41BAA2B9C00AF22F0 /* Blindside.m in Sources */,
+				AEBA4F1C1C4D628800C2FF80 /* NSObject+BlindsidePrivate.m in Sources */,
 				3420FCF51BAA2B9C00AF22F0 /* BSBlockProvider.m in Sources */,
 				3420FCF61BAA2B9C00AF22F0 /* BSClassProvider.m in Sources */,
 				3420FCFB1BAA2B9C00AF22F0 /* BSNull.m in Sources */,
@@ -1374,6 +1396,7 @@
 			files = (
 				34E710BE1B9F85DF0088AB71 /* NSObject+Blindside.m in Sources */,
 				34E710B31B9F85DF0088AB71 /* Blindside.m in Sources */,
+				AEBA4F1B1C4D628800C2FF80 /* NSObject+BlindsidePrivate.m in Sources */,
 				34E710B41B9F85DF0088AB71 /* BSBlockProvider.m in Sources */,
 				34E710B51B9F85DF0088AB71 /* BSClassProvider.m in Sources */,
 				34E710BA1B9F85DF0088AB71 /* BSNull.m in Sources */,
@@ -1402,6 +1425,7 @@
 			files = (
 				AE4864E71B06735F005DB302 /* Blindside.m in Sources */,
 				AE4864E81B06735F005DB302 /* BSBlockProvider.m in Sources */,
+				AEBA4F1A1C4D628800C2FF80 /* NSObject+BlindsidePrivate.m in Sources */,
 				AE4864E91B06735F005DB302 /* BSClassProvider.m in Sources */,
 				AE4864EA1B06735F005DB302 /* BSInitializer.m in Sources */,
 				AE4864EB1B06735F005DB302 /* BSInitializerProvider.m in Sources */,

--- a/Headers/Private/NSObject+BlindsidePrivate.h
+++ b/Headers/Private/NSObject+BlindsidePrivate.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSObject (BlindsidePrivate)
+
+/// A string used when printing errors about this object, when it used as an injector key
+- (NSString *)bsKeyDescription;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/BSInitializerProvider.m
+++ b/Source/BSInitializerProvider.m
@@ -5,6 +5,7 @@
 #import "BSNull.h"
 #import "BSPropertySet.h"
 #import "BSProperty.h"
+#import "NSObject+BlindsidePrivate.h"
 
 static NSString *const BSNilArgumentValue = @"BSNilArgumentValue";
 static NSString *const BSTooManyArguments = @"BSTooManyArguments";
@@ -67,7 +68,7 @@ static NSString *const BSTooManyArguments = @"BSTooManyArguments";
 }
 
 - (void)raiseNilValueExceptionForKey:(id)argKey {
-    NSString *argString = [argKey description];
+    NSString *argString = [argKey bsKeyDescription];
     NSString *classString = NSStringFromClass(self.initializer.type);
     [NSException raise:BSNilArgumentValue
                 format:@"No value was found for argument key: %@ for class: %@. This could mean you forgot to \

--- a/Source/BSInjectorImpl.m
+++ b/Source/BSInjectorImpl.m
@@ -11,6 +11,7 @@
 #import "BSClassProvider.h"
 #import "BSNull.h"
 #import "NSObject+Blindside.h"
+#import "NSObject+BlindsidePrivate.h"
 #import "BSUtils.h"
 #import <objc/runtime.h>
 
@@ -107,7 +108,7 @@ static NSString *const BSNilInjectionKeyException = @"BSNilInjectionKeyException
     }
 
     if (provider == nil && ![BS_DYNAMIC isEqual:key]) {
-        [NSException raise:BSNoProviderException format:@"Injector could not getInstance for key (%@) with args %@", key, args];
+        [NSException raise:BSNoProviderException format:@"Injector could not getInstance for key (%@) with args %@", [key bsKeyDescription], args];
     }
 
     return [self performWithInFlightKey:key block:^id{
@@ -175,7 +176,7 @@ static NSString *const BSNilInjectionKeyException = @"BSNilInjectionKeyException
 
 - (id)internalKey:(id)key {
     if ([NSStringFromClass([key class]) isEqualToString:@"Protocol"]) {
-        return [NSString stringWithFormat:@"@protocol(%@)", NSStringFromProtocol(key)];
+        return [key bsKeyDescription];
     }
     return key;
 }
@@ -184,7 +185,7 @@ static NSString *const BSNilInjectionKeyException = @"BSNilInjectionKeyException
 
 - (id)performWithInFlightKey:(id)key block:(id (^)(void))block {
     if ([self isKeyInFlight:key]) {
-        [NSException raise:BSCyclicDependencyException format:@"Cyclic dependency found on key %@. The dependency chain was:\n%@", key, [self cyclicDependencyChainDescription]];
+        [NSException raise:BSCyclicDependencyException format:@"Cyclic dependency found on key %@. The dependency chain was:\n%@", [key bsKeyDescription], [self cyclicDependencyChainDescription]];
     }
 
     [self addInFlightKey:key];

--- a/Source/NSObject+BlindsidePrivate.m
+++ b/Source/NSObject+BlindsidePrivate.m
@@ -1,0 +1,19 @@
+#import "NSObject+BlindsidePrivate.h"
+#import <objc/Protocol.h>
+#import <objc/runtime.h>
+
+@implementation NSObject (BlindsidePrivate)
+
+- (NSString *)bsKeyDescription {
+    return [self description];
+}
+
+@end
+
+@implementation Protocol (BlindsidePrivate)
+
+- (NSString *)bsKeyDescription {
+    return [NSString stringWithFormat:@"@protocol(%@)", NSStringFromProtocol(self)];
+}
+
+@end

--- a/Specs/BSInjectorSpec.mm
+++ b/Specs/BSInjectorSpec.mm
@@ -41,10 +41,20 @@ describe(@"BSInjector", ^{
         instance.bar should equal(@"BAR");
     });
 
-    it(@"raises an exception if the given key produces a nil object", ^{
-        ^{
-            [injector getInstance:@"NotAnInstance"];
-        } should raise_exception();
+    describe(@"getting an instance from an unbound key", ^{
+        it(@"should raise an exception", ^{
+            ^{
+                [injector getInstance:@"NotAnInstance"];
+            } should raise_exception();
+        });
+        
+        context(@"when the key is a protocol", ^{
+            it(@"should include the protocol name in the exception message", ^{
+                ^{
+                    [injector getInstance:@protocol(TestProtocol)];
+                } should raise_exception().with_reason(@"Injector could not getInstance for key (@protocol(TestProtocol)) with args (\n)");
+            });
+        });
     });
 
     describe(@"building an object using a BSInitializer", ^{


### PR DESCRIPTION
Inscrutable errors including strings like:
  “key \<Protocol: 0x12345678\>”
will now look like:
  “key @​protocol(MyProto)”