### PR TITLE
Stop directly referencing the `Protocol` class symbol

### DIFF
--- a/Source/NSObject+BlindsidePrivate.m
+++ b/Source/NSObject+BlindsidePrivate.m
@@ -1,19 +1,14 @@
 #import "NSObject+BlindsidePrivate.h"
-#import <objc/Protocol.h>
-#import <objc/runtime.h>
 
 @implementation NSObject (BlindsidePrivate)
 
 - (NSString *)bsKeyDescription {
-    return [self description];
-}
-
-@end
-
-@implementation Protocol (BlindsidePrivate)
-
-- (NSString *)bsKeyDescription {
-    return [NSString stringWithFormat:@"@protocol(%@)", NSStringFromProtocol(self)];
+    Class protocolClass = NSClassFromString(@"Protocol");
+    if (protocolClass != nil && [self isKindOfClass:protocolClass]) {
+        return [NSString stringWithFormat:@"@protocol(%@)", NSStringFromProtocol((Protocol *)self)];
+    } else {
+        return [self description];
+    }
 }
 
 @end


### PR DESCRIPTION
This class appears to have been moved private on some platforms with Xcode 7.3. Dynamically looking up the class at runtime still works though.