### PR TITLE
Use string comparison instead of pointer comparison within the has property method of BSPropertySet

### DIFF
--- a/Source/BSPropertySet.m
+++ b/Source/BSPropertySet.m
@@ -59,7 +59,7 @@
 
 - (BOOL)hasProperty:(BSProperty *)property {
     for (BSProperty *myProperty in self.properties) {
-        if (myProperty.propertyNameString == property.propertyNameString) {
+        if ([myProperty.propertyNameString isEqualToString:property.propertyNameString]) {
             return YES;
         }
     }


### PR DESCRIPTION
This is a parallel fix to the earlier fix referenced below. Did not include a test because the issue would only surface in very rare edge cases. However we wanted to commit the change to ensure that if and when the those edge cases occurred, a problem would not arise. 
https://github.com/jbsf/blindside/commit/fa1dc641dea66aad78978f6d05903f8c388076d1#diff-94ae95d3bd859ad3d016cd1286937847R50
