### PR TITLE
fix BSSingleton.source access with multi-thread

### DIFF
--- a/Source/BSSingleton.m
+++ b/Source/BSSingleton.m
@@ -2,7 +2,7 @@
 #import "BSProvider.h"
 
 @interface BSSingleton ()
-@property (nonatomic, strong) id<BSProvider> source;
+@property (atomic, strong) id<BSProvider> source;
 @property (nonatomic, strong) id instance;
 @end
 


### PR DESCRIPTION
dispatch_apply(1000, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(size_t idx) {
[inject getInstance:[TestClass class]]; // which bind to BSSingleton scope, because BSSingleton's source is nonatomic, will crash inside [scope scope:provider], the BSSingleton BSScope protocol implement.
}); 
